### PR TITLE
Cert_Approve_End1_Test_finish

### DIFF
--- a/src/main/java/org/example/wecambackend/config/auth/JwtAuthenticationFilter.java
+++ b/src/main/java/org/example/wecambackend/config/auth/JwtAuthenticationFilter.java
@@ -10,7 +10,7 @@ import org.example.wecambackend.model.User.User;
 import org.example.wecambackend.repos.UserRepository;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.context.SecurityContextHolder;
-import org.springframework.security.core.userdetails.UserDetailsService;
+import org.example.wecambackend.config.security.context.CurrentUserContext;
 import org.springframework.security.web.authentication.WebAuthenticationDetailsSource;
 import org.springframework.stereotype.Component;
 import org.springframework.web.filter.OncePerRequestFilter;
@@ -37,6 +37,7 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
         if (uri.equals("/affiliation-test.html")
                 || uri.startsWith("/public/")
                 || uri.equals("/login_example.html")
+                || uri.equals("/affiliation_approve_test.html")
                 || uri.startsWith("/css/")
                 || uri.startsWith("/js/")
                 || uri.startsWith("/images/")) {
@@ -75,6 +76,7 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
                 );
 
                 SecurityContextHolder.getContext().setAuthentication(authentication);
+                CurrentUserContext.set(userDetails);
             }
         }
 

--- a/src/main/java/org/example/wecambackend/config/security/CurrentUserArgumentResolver.java
+++ b/src/main/java/org/example/wecambackend/config/security/CurrentUserArgumentResolver.java
@@ -1,0 +1,33 @@
+package org.example.wecambackend.config.security;
+
+
+import org.example.wecambackend.config.security.annotation.CurrentUser;
+import org.example.wecambackend.exception.UnauthorizedException;
+import org.springframework.core.MethodParameter;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.stereotype.Component;
+import org.springframework.web.method.support.HandlerMethodArgumentResolver;
+import org.springframework.web.method.support.ModelAndViewContainer;
+
+@Component
+public class CurrentUserArgumentResolver implements HandlerMethodArgumentResolver {
+
+    @Override
+    public boolean supportsParameter(MethodParameter parameter) {
+        return parameter.hasParameterAnnotation(CurrentUser.class)
+                && parameter.getParameterType().equals(UserDetailsImpl.class);
+    }
+
+    @Override
+    public Object resolveArgument(MethodParameter parameter,
+                                  ModelAndViewContainer mavContainer,
+                                  org.springframework.web.context.request.NativeWebRequest webRequest,
+                                  org.springframework.web.bind.support.WebDataBinderFactory binderFactory) {
+        Authentication auth = SecurityContextHolder.getContext().getAuthentication();
+        if (auth == null || !auth.isAuthenticated()) {
+            throw new UnauthorizedException("로그인이 필요합니다.");
+        }
+        return (UserDetailsImpl) auth.getPrincipal();
+    }
+}

--- a/src/main/java/org/example/wecambackend/config/security/SecurityConfig.java
+++ b/src/main/java/org/example/wecambackend/config/security/SecurityConfig.java
@@ -34,6 +34,7 @@ public class SecurityConfig {
                 "/affiliation_test.html",
                 "/login_example.html",
                 "/signup_example.html",
+                "/affiliation_approve_test.html",
                 "/freshman_cert_example.html",
                 "/css/**",
                 "/js/**",
@@ -59,8 +60,8 @@ public class SecurityConfig {
                 .cors(cors -> cors.configurationSource(request -> {
                     CorsConfiguration config = new CorsConfiguration();
                     config.setAllowedOriginPatterns(List.of("*")); // 모든 Origin 허용
-                    config.setAllowedMethods(List.of("GET", "POST", "PUT", "DELETE", "OPTIONS"));
-                    config.setAllowedHeaders(List.of("Authorization", "Content-Type"));
+                    config.setAllowedMethods(List.of("*"));
+                    config.setAllowedHeaders(List.of("*"));
                     config.setAllowCredentials(true);
                     return config;
                 })) //Test 용 위에껀 프론트 연결용

--- a/src/main/java/org/example/wecambackend/config/security/WebConfig.java
+++ b/src/main/java/org/example/wecambackend/config/security/WebConfig.java
@@ -1,0 +1,19 @@
+package org.example.wecambackend.config.security;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.method.support.HandlerMethodArgumentResolver;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+import java.util.List;
+
+@Configuration
+@RequiredArgsConstructor
+public class WebConfig implements WebMvcConfigurer {
+    private final CurrentUserArgumentResolver currentUserArgumentResolver;
+
+    @Override
+    public void addArgumentResolvers(List<HandlerMethodArgumentResolver> resolvers) {
+        resolvers.add(currentUserArgumentResolver);
+    }
+}

--- a/src/main/java/org/example/wecambackend/config/security/annotation/CurrentUser.java
+++ b/src/main/java/org/example/wecambackend/config/security/annotation/CurrentUser.java
@@ -1,0 +1,9 @@
+package org.example.wecambackend.config.security.annotation;
+
+import java.lang.annotation.*;
+
+@Target(ElementType.PARAMETER)
+@Retention(RetentionPolicy.RUNTIME)
+@Documented
+public @interface CurrentUser {
+}

--- a/src/main/java/org/example/wecambackend/config/security/annotation/HasAffiliationApprovalAuthority.java
+++ b/src/main/java/org/example/wecambackend/config/security/annotation/HasAffiliationApprovalAuthority.java
@@ -1,0 +1,11 @@
+package org.example.wecambackend.config.security.annotation;
+
+import java.lang.annotation.*;
+
+@Target({ElementType.METHOD, ElementType.TYPE})
+@Retention(RetentionPolicy.RUNTIME)
+@Documented
+public @interface HasAffiliationApprovalAuthority {
+    // TODO: 추후 role, permission 등 확장 가능
+    //현재는 로직 구현을 안 해둠.
+}

--- a/src/main/java/org/example/wecambackend/config/security/aspect/RoleCheckAspect.java
+++ b/src/main/java/org/example/wecambackend/config/security/aspect/RoleCheckAspect.java
@@ -4,21 +4,17 @@ import lombok.RequiredArgsConstructor;
 import org.aspectj.lang.annotation.Aspect;
 import org.aspectj.lang.annotation.Before;
 import org.example.wecambackend.config.security.UserDetailsImpl;
-import org.example.wecambackend.exception.UnauthorizedException;
 import org.example.wecambackend.model.enums.UserRole;
 import org.example.wecambackend.repos.CouncilMemberRepository;
-import org.example.wecambackend.service.client.UserService;
+import org.example.wecambackend.util.CurrentUserUtil;
 import org.springframework.security.access.AccessDeniedException;
-import org.springframework.security.core.Authentication;
-import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.stereotype.Component;
-
 
 @Aspect
 @Component
 @RequiredArgsConstructor
 public class RoleCheckAspect {
-    private final UserService userService;
+
     private final CouncilMemberRepository councilMemberRepository;
 
     @Before("@annotation(org.example.wecambackend.config.security.annotation.IsStudent)")
@@ -26,13 +22,14 @@ public class RoleCheckAspect {
         checkUserRole(UserRole.STUDENT);
     }
 
-    //학생회 관리자 페이지 (해당 조직의 학생회의 멤버인지, user_role또한 확인)
     @Before("@annotation(org.example.wecambackend.config.security.annotation.IsCouncil)")
     public void checkCouncil() {
-        UserDetailsImpl currentUser = getCurrentUser(); // 로그인된 유저 불러오기
+        UserDetailsImpl currentUser = getCurrentUser();
+
         if (currentUser.getRole() != UserRole.COUNCIL) {
             throw new AccessDeniedException("학생회 권한이 없습니다.");
         }
+
         boolean isCouncilMember = councilMemberRepository.existsByUserUserPkIdAndCouncil_Organization_organizationIdAndIsActiveTrue(
                 currentUser.getId(), currentUser.getOrganizationId());
 
@@ -41,47 +38,27 @@ public class RoleCheckAspect {
         }
     }
 
-    //신입생 소속인증 진행은 완료되면 다시 진행하지 못함.(UnAuth -> Guest_Student 에서 사용)
     @Before("@annotation(org.example.wecambackend.config.security.annotation.IsUnauth)")
     public void checkUnauth() {
         checkUserRole(UserRole.UNAUTH);
     }
 
-    //재학생 소속인증 진행은 신입생 인증을 완료한 Guest_Student , Unauth 만 진행이 가능
     @Before("@annotation(org.example.wecambackend.config.security.annotation.IsUnStudent)")
     public void checkUnStudent() {
-        UserRole role = getCurrentUserRole();
+        UserRole role = getCurrentUser().getRole();
+
         if (role != UserRole.GUEST_STUDENT && role != UserRole.UNAUTH) {
             throw new AccessDeniedException("접근이 불가합니다.");
         }
     }
 
-    private UserRole getCurrentUserRole() {
-        Authentication auth = SecurityContextHolder.getContext().getAuthentication();
-        if (auth == null || !auth.isAuthenticated()) {
-            throw new AccessDeniedException("인증되지 않은 사용자입니다.");
-        }
-
-        UserDetailsImpl user = (UserDetailsImpl) auth.getPrincipal();
-        return user.getRole();
-    }
-
-    private UserDetailsImpl getCurrentUser() {
-        Authentication auth = SecurityContextHolder.getContext().getAuthentication();
-        if (auth == null || !auth.isAuthenticated()) {
-            throw new UnauthorizedException("로그인이 필요합니다.");
-        }
-
-        UserDetailsImpl userDetails = (UserDetailsImpl) auth.getPrincipal();
-        return userDetails;
-    }
-
-
     private void checkUserRole(UserRole requiredRole) {
-        if (getCurrentUserRole() != requiredRole) {
+        if (getCurrentUser().getRole() != requiredRole) {
             throw new AccessDeniedException(requiredRole.name() + "만 접근할 수 있습니다.");
         }
     }
 
-
+    private UserDetailsImpl getCurrentUser() {
+        return CurrentUserUtil.getCurrentUserDetails();
+    }
 }

--- a/src/main/java/org/example/wecambackend/config/security/context/CurrentUserContext.java
+++ b/src/main/java/org/example/wecambackend/config/security/context/CurrentUserContext.java
@@ -1,0 +1,19 @@
+package org.example.wecambackend.config.security.context;
+
+import org.example.wecambackend.config.security.UserDetailsImpl;
+
+public class CurrentUserContext {
+    private static final ThreadLocal<UserDetailsImpl> currentUserHolder = new ThreadLocal<>();
+
+    public static void set(UserDetailsImpl user) {
+        currentUserHolder.set(user);
+    }
+
+    public static UserDetailsImpl get() {
+        return currentUserHolder.get();
+    }
+
+    public static void clear() {
+        currentUserHolder.remove();
+    }
+}

--- a/src/main/java/org/example/wecambackend/config/security/filter/CurrentUserContextCleanupFilter.java
+++ b/src/main/java/org/example/wecambackend/config/security/filter/CurrentUserContextCleanupFilter.java
@@ -1,0 +1,30 @@
+package org.example.wecambackend.config.security.filter;
+
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.example.wecambackend.config.security.context.CurrentUserContext;
+import org.springframework.core.Ordered;
+import org.springframework.core.annotation.Order;
+import org.springframework.stereotype.Component;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import java.io.IOException;
+
+@Component
+@Order(Ordered.HIGHEST_PRECEDENCE + 10) //JwtAuthenticationFilter 이후에 실행되게 설정
+public class CurrentUserContextCleanupFilter extends OncePerRequestFilter {
+    @Override
+    protected void doFilterInternal(HttpServletRequest request,
+                                    HttpServletResponse response,
+                                    FilterChain filterChain)
+            throws ServletException, IOException {
+        try {
+            filterChain.doFilter(request, response);
+        } finally {
+            CurrentUserContext.clear(); //  요청 끝나면 클리어
+        }
+    }
+}
+

--- a/src/main/java/org/example/wecambackend/exception/GlobalExceptionHandler.java
+++ b/src/main/java/org/example/wecambackend/exception/GlobalExceptionHandler.java
@@ -1,15 +1,20 @@
 package org.example.wecambackend.exception;
 
 import org.example.wecambackend.exception.dto.ErrorResponse;
+import org.springframework.core.Ordered;
+import org.springframework.core.annotation.Order;
 import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.AccessDeniedException;
+import org.springframework.web.bind.annotation.ControllerAdvice;
 import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.ResponseBody;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 
 //TODO : 왠지모르겠지만 이거 주석 처리 하니까 잘 뜸...Swagger 추후 다시 주석 풀어야됨.
 //@RestControllerAdvice
+//@Order(Ordered.HIGHEST_PRECEDENCE)
 public class GlobalExceptionHandler {
 
     // 1. 접근 권한 예외 처리
@@ -46,6 +51,7 @@ public class GlobalExceptionHandler {
 
     // 4. 로그인 필요 메세지
     @ExceptionHandler(UnauthorizedException.class)
+    @ResponseBody
     public ResponseEntity<ErrorResponse> handleUnauthorizedException(UnauthorizedException ex) {
         ErrorResponse error = new ErrorResponse(
                 HttpStatus.UNAUTHORIZED.value(), // 401

--- a/src/main/java/org/example/wecambackend/model/User/User.java
+++ b/src/main/java/org/example/wecambackend/model/User/User.java
@@ -31,7 +31,7 @@ public class User {
     private String email;
 
     /** 계정 만료일 (가입일 기준 30일 후 자동 설정됨) */
-    @Column(name = "expires_at", nullable = false)
+    @Column(name = "expires_at")
     private LocalDateTime expiresAt;
 
     /** 계정 생성일 */

--- a/src/main/java/org/example/wecambackend/model/User/UserInformation.java
+++ b/src/main/java/org/example/wecambackend/model/User/UserInformation.java
@@ -56,5 +56,6 @@ public class UserInformation extends BaseTimeEntity {
 
     @Column(name = "is_council_fee", nullable = false)
     private Boolean isCouncilFee;
-    // 생략된 부분 추가 가능
+
+
 }

--- a/src/main/java/org/example/wecambackend/model/User/UserSignupInformation.java
+++ b/src/main/java/org/example/wecambackend/model/User/UserSignupInformation.java
@@ -53,4 +53,5 @@ public class UserSignupInformation extends BaseTimeEntity {
     @Builder.Default
     private Boolean isMakeWorkspace = false;
 
+
 }

--- a/src/main/java/org/example/wecambackend/model/affiliation/AffiliationCertification.java
+++ b/src/main/java/org/example/wecambackend/model/affiliation/AffiliationCertification.java
@@ -55,6 +55,9 @@ public class AffiliationCertification {
     @Column(name = "reason", columnDefinition = "TEXT")
     private String reason;
 
+    @Column(name = "user_name", length = 20)
+    private String username;
+
     @Column(name = "requested_at")
     private LocalDateTime requestedAt;
 
@@ -74,5 +77,19 @@ public class AffiliationCertification {
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "organization_pk_id")
     private Organization organization;
+
+
+    //소속 인증 승인 처리
+    public void approve(User reviewer) {
+        this.status = AuthenticationStatus.APPROVED;
+        this.reviewUser = reviewer;
+        this.reviewedAt = LocalDateTime.now();
+    }
+
+    //소속인증 처리 확인
+    public boolean isApprovable() {
+        return this.status == AuthenticationStatus.PENDING;
+    }
+
 
 }

--- a/src/main/java/org/example/wecambackend/repos/UserInformationRepository.java
+++ b/src/main/java/org/example/wecambackend/repos/UserInformationRepository.java
@@ -1,0 +1,8 @@
+package org.example.wecambackend.repos;
+
+import org.example.wecambackend.model.User.UserInformation;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface UserInformationRepository extends JpaRepository<UserInformation,Long> {
+
+}

--- a/src/main/java/org/example/wecambackend/repos/affiliation/AffiliationCertificationRepository.java
+++ b/src/main/java/org/example/wecambackend/repos/affiliation/AffiliationCertificationRepository.java
@@ -5,6 +5,7 @@ import org.example.wecambackend.model.Organization;
 import org.example.wecambackend.model.User.User;
 //import org.example.wecambackend.model.affiliation.AffiliationCertification;
 import org.example.wecambackend.model.affiliation.AffiliationCertification;
+import org.example.wecambackend.model.affiliation.AffiliationCertificationId;
 import org.example.wecambackend.model.enums.AuthenticationType;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
@@ -13,7 +14,7 @@ import org.springframework.data.repository.query.Param;
 import java.util.List;
 
 public interface AffiliationCertificationRepository extends
-        JpaRepository<AffiliationCertification, Long>{ // ← 이거 추가!
+        JpaRepository<AffiliationCertification, AffiliationCertificationId>{
 
 
     //조직별 요청서 확인

--- a/src/main/java/org/example/wecambackend/service/admin/AffiliationCertificationAdminService.java
+++ b/src/main/java/org/example/wecambackend/service/admin/AffiliationCertificationAdminService.java
@@ -1,27 +1,41 @@
 package org.example.wecambackend.service.admin;
 
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.example.wecambackend.config.security.UserDetailsImpl;
 import org.example.wecambackend.dto.projection.AffiliationFileProjection;
 import org.example.wecambackend.dto.responseDTO.AffiliationVerificationResponse;
+import org.example.wecambackend.exception.UnauthorizedException;
 import org.example.wecambackend.model.Council;
+import org.example.wecambackend.model.User.User;
 import org.example.wecambackend.model.affiliation.AffiliationCertification;
 import org.example.wecambackend.model.affiliation.AffiliationCertificationId;
 import org.example.wecambackend.model.enums.AuthenticationType;
 import org.example.wecambackend.repos.CouncilRepository;
+import org.example.wecambackend.repos.UserRepository;
 import org.example.wecambackend.repos.affiliation.AffiliationCertificationRepository;
 import org.example.wecambackend.repos.affiliation.AffiliationFileRepository;
+import org.example.wecambackend.service.client.UserService;
 import org.springframework.stereotype.Service;
-import org.example.wecambackend.model.affiliation.AffiliationFile;
+import org.springframework.transaction.annotation.Transactional;
 
+import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
 
+@Slf4j
 @Service
 @RequiredArgsConstructor
 public class AffiliationCertificationAdminService {
     private final AffiliationCertificationRepository affiliationCertificationRepository;
     private final AffiliationFileRepository affiliationFileRepository;
     private final CouncilRepository councilRepository;
+    private final UserService userService;
+    private final UserInformationService userInformationService;
+    private final UserRepository userRepository;
+
+
+
     public List<AffiliationVerificationResponse> getRequestsForOrganization(Long organizationId) {
         List<AffiliationCertification> certifications =
                 affiliationCertificationRepository.findByOrganizationOrganizationIdOrderByRequestedAtDesc(organizationId);
@@ -31,8 +45,7 @@ public class AffiliationCertificationAdminService {
             Long userId = ac.getId().getUserId();
             AuthenticationType authenticationType = ac.getId().getAuthenticationType();
             AffiliationCertificationId id = ac.getId();
-//            Optional<AffiliationFile> optionalFile = affiliationFileRepository
-//                    .findByUserIdAndAuthOrdinal(userId,ac.getAuthenticationType().ordinal());
+
             Optional<AffiliationFileProjection> optionalFile = affiliationFileRepository.findFilePathAndNameByUserIdAndAuthOrdinal(userId, authenticationType.ordinal());
             System.out.println("조회된 파일: " + optionalFile);
             String filePath = optionalFile.map(file -> file.getFilePath()).orElse(null);
@@ -52,6 +65,7 @@ public class AffiliationCertificationAdminService {
         }).toList();
     }
 
+    @Transactional
     public List<AffiliationVerificationResponse> getRequestsByCouncilId(Long councilId) {
         Council council = councilRepository.findById(councilId)
                 .orElseThrow(() -> new RuntimeException("해당 학생회를 찾을 수 없습니다."));
@@ -60,4 +74,35 @@ public class AffiliationCertificationAdminService {
 
         return getRequestsForOrganization(organizationId);
     }
+
+    //복합 도메인 트랜잭션 처리->
+    @Transactional
+    public void approveAffiliationRequest(AffiliationCertificationId id, Long councilId,UserDetailsImpl currentUser) {
+        // 인증 요청 조회
+        AffiliationCertification cert = affiliationCertificationRepository.findById(id)
+                .orElseThrow(() -> new IllegalArgumentException("해당 인증 요청을 찾을 수 없습니다."));
+
+
+        // 요청이 해당 councilId가 관리하는 범위에 있는지 검증 (선택) --- TODO: 할지 말지 모르겠음. 우선 제외
+        User uploadUser = cert.getUser();
+        AuthenticationType type = cert.getAuthenticationType();
+        User reviewUser = userRepository.findById(currentUser.getId())
+                .orElseThrow(() -> new RuntimeException("리뷰어 유저 없음"));
+        markApproved(cert,reviewUser);
+        userInformationService.createUserInformation(uploadUser, cert);
+        userService.updateUserRoleAndStatus(uploadUser, cert.getOrganization(),cert.getUniversity(), type);
+        log.info("[소속 인증 승인] {}가 {}의 인증 요청을 승인함",
+                reviewUser.getEmail(),
+                uploadUser.getEmail());
+    }
+
+
+    public void markApproved(AffiliationCertification cert, User reviwerUser) {
+        if (!cert.isApprovable()) {
+            throw new IllegalStateException("이미 처리된 요청입니다.");
+        }
+        cert.approve(reviwerUser);
+        affiliationCertificationRepository.save(cert); // dirty checking 보장 안되면 save
+    }
+
 }

--- a/src/main/java/org/example/wecambackend/service/admin/UserInformationService.java
+++ b/src/main/java/org/example/wecambackend/service/admin/UserInformationService.java
@@ -1,0 +1,30 @@
+package org.example.wecambackend.service.admin;
+
+import lombok.RequiredArgsConstructor;
+import org.example.wecambackend.model.User.User;
+import org.example.wecambackend.model.User.UserInformation;
+import org.example.wecambackend.model.affiliation.AffiliationCertification;
+import org.example.wecambackend.repos.UserInformationRepository;
+import org.springframework.stereotype.Service;
+
+import java.time.LocalDateTime;
+
+@Service
+@RequiredArgsConstructor
+public class UserInformationService {
+
+
+    private final UserInformationRepository userInformationRepository;
+    public void createUserInformation( User user, AffiliationCertification cert) {
+        UserInformation info = UserInformation.builder()
+                .user(user)
+                .name(cert.getUsername())
+                .university(cert.getUniversity())
+                .isAuthentication(Boolean.TRUE)
+                .studentId(cert.getOcrEnrollYear())
+                .isCouncilFee(Boolean.FALSE)
+                .build();
+
+        userInformationRepository.save(info);
+    }
+}

--- a/src/main/java/org/example/wecambackend/service/client/Affiliation/AffiliationService.java
+++ b/src/main/java/org/example/wecambackend/service/client/Affiliation/AffiliationService.java
@@ -102,6 +102,7 @@ public class AffiliationService {
                 .requestedAt(LocalDateTime.now())
                 .organization(organization)
                 .university(school)
+                 .username(signupInfo.getName())
                 .build();
 
         affiliationCertificationRepository.save(cert);

--- a/src/main/java/org/example/wecambackend/service/client/UserService.java
+++ b/src/main/java/org/example/wecambackend/service/client/UserService.java
@@ -1,7 +1,44 @@
 package org.example.wecambackend.service.client;
 
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.example.wecambackend.model.Organization;
+import org.example.wecambackend.model.University;
+import org.example.wecambackend.model.User.User;
+import org.example.wecambackend.model.affiliation.AffiliationCertification;
+import org.example.wecambackend.model.enums.AuthenticationType;
+import org.example.wecambackend.model.enums.UserRole;
+import org.example.wecambackend.repos.UserRepository;
 import org.springframework.stereotype.Service;
 
+import java.time.LocalDateTime;
+
+@Slf4j
 @Service
+@RequiredArgsConstructor
 public class UserService {
+
+    private final UserRepository userRepository;
+    public void updateUserRoleAndStatus(User user, Organization organization, University university, AuthenticationType authenticationType) {
+        UserRole beforeRole = user.getRole();
+        if (authenticationType == AuthenticationType.NEW_STUDENT) {
+            user.setRole(UserRole.GUEST_STUDENT); // enum 기반
+        }
+        else {
+            user.setRole(UserRole.STUDENT);
+        }
+        if (!beforeRole.equals(user.getRole())) {
+            user.setExpiresAt(null); // TODO : 우선 ROLE 이 바뀌면 ExpiresAt은 비활성화 시켰음.
+        }
+        user.setUniversity(university);
+        user.setOrganization(organization);
+
+        userRepository.save(user);
+        log.info("[유저 상태 변경] {}: {} → {}, 학교: {}, 조직: {}",
+                user.getEmail(),
+                beforeRole.name(),
+                user.getRole().name(),
+                university.getSchoolName(),
+                organization.getOrganizationName());
+    }
 }

--- a/src/main/java/org/example/wecambackend/util/CurrentUserUtil.java
+++ b/src/main/java/org/example/wecambackend/util/CurrentUserUtil.java
@@ -1,0 +1,35 @@
+package org.example.wecambackend.util;
+
+import org.example.wecambackend.config.security.context.CurrentUserContext;
+import org.example.wecambackend.config.security.UserDetailsImpl;
+import org.example.wecambackend.exception.UnauthorizedException;
+import org.example.wecambackend.model.enums.UserRole;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+
+public class CurrentUserUtil {
+    public static UserDetailsImpl getCurrentUserDetails() {
+        UserDetailsImpl cached = CurrentUserContext.get();
+        if (cached != null) return cached;
+
+        Authentication auth = SecurityContextHolder.getContext().getAuthentication();
+        if (auth == null || !auth.isAuthenticated()) {
+            throw new UnauthorizedException("로그인이 필요합니다.");
+        }
+
+        return (UserDetailsImpl) auth.getPrincipal();
+    }
+
+    public static Long getUserId() {
+        return getCurrentUserDetails().getId();
+    }
+
+    public static Long getOrganizationId() {
+        return getCurrentUserDetails().getOrganizationId();
+    }
+
+    public static UserRole getRole() {
+        return getCurrentUserDetails().getRole();
+    }
+}
+

--- a/src/main/resources/db/schema.sql
+++ b/src/main/resources/db/schema.sql
@@ -17,3 +17,7 @@ WHERE authentication_type = '1';
 
 SELECT * FROM affiliation_file
 WHERE pk_upload_userid = 1 AND authentication_type = 'NEW_STUDENT';
+
+
+ALTER TABLE affiliation_certification ADD COLUMN user_name VARCHAR(255);
+ALTER TABLE user MODIFY expires_at DATETIME NULL;

--- a/src/main/resources/static/affiliation_approve_test.html
+++ b/src/main/resources/static/affiliation_approve_test.html
@@ -1,0 +1,101 @@
+<!DOCTYPE html>
+<html lang="ko">
+<head>
+    <meta charset="UTF-8">
+    <title>학생회 소속 인증 요청 관리</title>
+</head>
+<body>
+<h2>소속 인증 요청 목록 조회</h2>
+
+<label for="councilName">학생회 이름 (화면용)</label><br>
+<input type="text" id="councilName" value="컴공학생회"><br><br>
+
+<label for="councilId">councilId</label><br>
+<input type="number" id="councilId" value="1"><br><br>
+
+<button onclick="fetchRequests()">조회하기</button>
+
+<h3>요청 결과</h3>
+<table border="1" id="resultTable">
+    <thead>
+    <tr>
+        <th>인증 ID</th>
+        <th>이메일</th>
+        <th>인증 유형</th>
+        <th>상태</th>
+        <th>승인</th>
+    </tr>
+    </thead>
+    <tbody id="resultBody"></tbody>
+</table>
+
+<script>
+    async function fetchRequests() {
+
+        const councilName = document.getElementById("councilName").value;
+        const councilId = document.getElementById("councilId").value;
+        const token = localStorage.getItem("accessToken");
+
+        const url = `/admin/council/${encodeURIComponent(councilName)}/affiliation/requests?councilId=${councilId}`;
+
+        try {
+            const res = await fetch(url, {
+                headers: {
+                    "Authorization": `Bearer ${token}`,
+                    "Accept": "application/json"
+                }
+            });
+
+            const data = await res.json();
+            const tbody = document.getElementById("resultBody");
+            tbody.innerHTML = "";
+
+            data.forEach(item => {
+                const row = document.createElement("tr");
+
+                row.innerHTML = `
+                    <td>${item.userId}</td>
+                    <td>${item.userName}</td>
+                    <td>${item.authenticationType}</td>
+                    <td>${item.status}</td>
+                    <td><button onclick="approve(${item.userId}, '${item.authenticationType}')">승인</button></td>
+                `;
+                console.log("item.certId = ", item.Id);
+                tbody.appendChild(row);
+            });
+
+        } catch (e) {
+            alert("조회 실패: " + e.message);
+        }
+    }
+
+    async function approve(userId, authType) {
+        const councilName = document.getElementById("councilName").value;
+        const councilId = document.getElementById("councilId").value;
+        const token = localStorage.getItem("accessToken");
+
+        const url = `/admin/council/${encodeURIComponent(councilName)}/affiliation/approve?userId=${userId}&authType=${authType}&councilId=${councilId}`;
+
+        try {
+            const res = await fetch(url, {
+                method: "POST",
+                headers: {
+                    "Authorization": `Bearer ${token}`,
+                    "Content-Type": "application/json"
+                }
+            });
+
+            if (res.ok) {
+                alert("승인 완료!");
+                fetchRequests();
+            } else {
+                const error = await res.text();
+                alert("승인 실패: " + error);
+            }
+        } catch (e) {
+            alert("요청 실패: " + e.message);
+        }
+    }
+</script>
+</body>
+</html>

--- a/src/main/resources/static/login_example.html
+++ b/src/main/resources/static/login_example.html
@@ -17,7 +17,9 @@
 
 <div id="afterLogin" style="display:none;">
     <p>로그인 성공!</p>
-    <button onclick="goToAffiliation()">소속 인증 요청 페이지로</button>
+    <button onclick="goToAffiliation()">소속 인증 조회  페이지로</button>
+    <button onclick="goToAffiliationApprove()">소속 인증 승인 페이지로</button>
+
 </div>
 
 <p id="result"></p>
@@ -60,5 +62,9 @@
 
     function goToAffiliation() {
         window.location.href = "/affiliation_test.html";
+    }
+
+    function goToAffiliationApprove() {
+        window.location.href = "/affiliation_approve_test.html";
     }
 </script>


### PR DESCRIPTION
🎯 학생회 관리자 소속 인증 승인 기능 구현
✅ 주요 기능
/admin/council/{councilName}/affiliation/{id}/approve?councilId={councilId} API 구현
→ 해당 학생회의 승인 권한을 가진 관리자가 인증 요청을 승인 가능하도록 처리

@HasAffiliationApprovalAuthority 어노테이션 기반 권한 제어

✅ 주요 서비스 로직
AffiliationCertificationAdminService.approveAffiliationRequest(...)
→ 인증 요청 승인, 유저 정보 등록, 유저 역할/소속 변경, 로그 출력 포함

UserInformationService.createUserInformation()
→ 인증 요청 정보를 기반으로 UserInformation 신규 생성

UserService.updateUserRoleAndStatus()
→ 인증 유형에 따라 유저 role 갱신 + 학교/학과 정보 반영
→ NEW_STUDENT → GUEST_STUDENT / 재학생은 STUDENT로 설정
→ role이 바뀔 경우 expiresAt = null 처리

✅ 로그 추가
관리자와 유저 이메일 기반 승인 로그 출력

✅ 테스트용 HTML 뷰 구현
인증 요청 조회 및 승인 기능 포함된 테스트 HTML 페이지 작성

승인 버튼 클릭 시 인증 요청 승인 API POST 호출

⚠️ 주의사항
UserInformation.isCouncilFee, UserInformation.name, User.expiresAt 등 not-null 필드 누락 시 오류 발생
→ 해당 필드는 모두 서비스 로직에서 명시적으로 채워야 함
→ nullable 허용하려면 @Column(nullable = true) 또는 DB alter 필요