### PR TITLE
My page 1

### DIFF
--- a/src/main/java/org/example/wecambackend/config/auth/JwtAuthenticationFilter.java
+++ b/src/main/java/org/example/wecambackend/config/auth/JwtAuthenticationFilter.java
@@ -38,6 +38,7 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
                 || uri.startsWith("/public/")
                 || uri.equals("/login_example.html")
                 || uri.equals("/affiliation_approve_test.html")
+                || uri.equals("/mypage_example.html")
                 || uri.startsWith("/css/")
                 || uri.startsWith("/js/")
                 || uri.startsWith("/images/")) {

--- a/src/main/java/org/example/wecambackend/config/security/SecurityConfig.java
+++ b/src/main/java/org/example/wecambackend/config/security/SecurityConfig.java
@@ -36,6 +36,7 @@ public class SecurityConfig {
                 "/signup_example.html",
                 "/affiliation_approve_test.html",
                 "/freshman_cert_example.html",
+                "/mypage_example.html",
                 "/css/**",
                 "/js/**",
                 "/images/**"

--- a/src/main/java/org/example/wecambackend/controller/client/UserMyPageController.java
+++ b/src/main/java/org/example/wecambackend/controller/client/UserMyPageController.java
@@ -1,25 +1,30 @@
-package org.example.wecambackend.controller.client;
-
-
-import io.swagger.v3.oas.annotations.tags.Tag;
-import lombok.RequiredArgsConstructor;
-import org.example.wecambackend.config.security.UserDetailsImpl;
-import org.example.wecambackend.config.security.annotation.CurrentUser;
-import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
-
-
-@RestController
-@RequiredArgsConstructor
-@RequestMapping("client/user/mypage")
-@Tag(name = "",description = "")
-public class UserMyPageController {
-
-    @GetMapping
-    public ResponseEntity<MyPageResponse> getMyInfo(@CurrentUser UserDetailsImpl currentUser) {
-        return ResponseEntity.ok(myPageService.getMyPageInfo(currentUser));
-    }
-
-}
+//package org.example.wecambackend.controller.client;
+//
+//
+//import io.swagger.v3.oas.annotations.tags.Tag;
+//import lombok.RequiredArgsConstructor;
+//import org.example.wecambackend.config.security.UserDetailsImpl;
+//import org.example.wecambackend.config.security.annotation.CurrentUser;
+//import org.example.wecambackend.dto.responseDTO.MyPageResponse;
+//import org.example.wecambackend.service.client.MyPageService;
+//import org.springframework.http.ResponseEntity;
+//import org.springframework.web.bind.annotation.GetMapping;
+//import org.springframework.web.bind.annotation.RequestMapping;
+//import org.springframework.web.bind.annotation.RestController;
+//
+//
+//@RestController
+//@RequiredArgsConstructor
+//@RequestMapping("client/user/mypage")
+//@Tag(name = "",description = "")
+//public class UserMyPageController {
+//
+//    private final MyPageService myPageService;
+//
+//    @GetMapping
+//    public ResponseEntity<MyPageResponse> getMyInfo(@CurrentUser UserDetailsImpl currentUser) {
+//        return ResponseEntity.ok(myPageService.getMyPageInfo(currentUser));
+//
+//    }
+//
+//}

--- a/src/main/java/org/example/wecambackend/controller/client/UserMyPageController.java
+++ b/src/main/java/org/example/wecambackend/controller/client/UserMyPageController.java
@@ -1,12 +1,25 @@
-//package org.example.wecambackend.controller.client;
-//
-//
-//import lombok.RequiredArgsConstructor;
-//import org.springframework.stereotype.Controller;
-//import org.springframework.web.bind.annotation.RequestMapping;
-//
-//@Controller
-//@RequiredArgsConstructor
-//@RequestMapping("client/user/mypage")
-//public class UserMyPageController {
-//}
+package org.example.wecambackend.controller.client;
+
+
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.example.wecambackend.config.security.UserDetailsImpl;
+import org.example.wecambackend.config.security.annotation.CurrentUser;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("client/user/mypage")
+@Tag(name = "",description = "")
+public class UserMyPageController {
+
+    @GetMapping
+    public ResponseEntity<MyPageResponse> getMyInfo(@CurrentUser UserDetailsImpl currentUser) {
+        return ResponseEntity.ok(myPageService.getMyPageInfo(currentUser));
+    }
+
+}

--- a/src/main/java/org/example/wecambackend/controller/client/UserMyPageController.java
+++ b/src/main/java/org/example/wecambackend/controller/client/UserMyPageController.java
@@ -1,30 +1,31 @@
-//package org.example.wecambackend.controller.client;
-//
-//
-//import io.swagger.v3.oas.annotations.tags.Tag;
-//import lombok.RequiredArgsConstructor;
-//import org.example.wecambackend.config.security.UserDetailsImpl;
-//import org.example.wecambackend.config.security.annotation.CurrentUser;
-//import org.example.wecambackend.dto.responseDTO.MyPageResponse;
-//import org.example.wecambackend.service.client.MyPageService;
-//import org.springframework.http.ResponseEntity;
-//import org.springframework.web.bind.annotation.GetMapping;
-//import org.springframework.web.bind.annotation.RequestMapping;
-//import org.springframework.web.bind.annotation.RestController;
-//
-//
-//@RestController
-//@RequiredArgsConstructor
-//@RequestMapping("client/user/mypage")
-//@Tag(name = "",description = "")
-//public class UserMyPageController {
-//
-//    private final MyPageService myPageService;
-//
-//    @GetMapping
-//    public ResponseEntity<MyPageResponse> getMyInfo(@CurrentUser UserDetailsImpl currentUser) {
-//        return ResponseEntity.ok(myPageService.getMyPageInfo(currentUser));
-//
-//    }
-//
-//}
+package org.example.wecambackend.controller.client;
+
+
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.example.wecambackend.config.security.UserDetailsImpl;
+import org.example.wecambackend.config.security.annotation.CurrentUser;
+import org.example.wecambackend.dto.responseDTO.MyPageResponse;
+import org.example.wecambackend.service.client.MyPageService;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("client/user/mypage")
+@Tag(name = "User MyPage Controller ",description = "유저 마이페이지 - 권한 ; 로그인한 유저(client/)")
+public class UserMyPageController {
+
+    private final MyPageService myPageService;
+
+    @GetMapping
+    public ResponseEntity<MyPageResponse> getMyInfo(@AuthenticationPrincipal UserDetailsImpl userDetails) {
+        return ResponseEntity.ok(myPageService.getMyPageInfo(userDetails));
+
+    }
+
+}

--- a/src/main/java/org/example/wecambackend/dto/projection/OcrEvaluationResult.java
+++ b/src/main/java/org/example/wecambackend/dto/projection/OcrEvaluationResult.java
@@ -1,0 +1,19 @@
+package org.example.wecambackend.dto.projection;
+
+import lombok.Getter;
+import lombok.Setter;
+import org.example.wecambackend.model.enums.OcrResult;
+
+
+@Getter
+@Setter
+public class OcrEvaluationResult {
+
+    private final OcrResult result;
+    private final String reason;
+
+    public OcrEvaluationResult(OcrResult result, String reason) {
+        this.result = result;
+        this.reason = reason;
+    }
+}

--- a/src/main/java/org/example/wecambackend/dto/responseDTO/MyPageResponse.java
+++ b/src/main/java/org/example/wecambackend/dto/responseDTO/MyPageResponse.java
@@ -20,4 +20,5 @@ public class MyPageResponse {
     private Boolean isCouncilFee; // 학생회비 인증 완료했는지 여부
     private Boolean nickName; //닉네임
     private Boolean studentId; //학번
+
 }

--- a/src/main/java/org/example/wecambackend/dto/responseDTO/MyPageResponse.java
+++ b/src/main/java/org/example/wecambackend/dto/responseDTO/MyPageResponse.java
@@ -16,5 +16,8 @@ public class MyPageResponse {
     private Boolean academicStatus; //학적 상태
     private UserRole role;
     private int student_grade;
-
+    private Boolean isAuthentication; //소속인증을 완료했는지 여부
+    private Boolean isCouncilFee; // 학생회비 인증 완료했는지 여부
+    private Boolean nickName; //닉네임
+    private Boolean studentId; //학번
 }

--- a/src/main/java/org/example/wecambackend/dto/responseDTO/MyPageResponse.java
+++ b/src/main/java/org/example/wecambackend/dto/responseDTO/MyPageResponse.java
@@ -1,0 +1,20 @@
+package org.example.wecambackend.dto.responseDTO;
+
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.example.wecambackend.model.enums.UserRole;
+
+@Getter
+@AllArgsConstructor
+public class MyPageResponse {
+    private String username; //이름
+    private String phoneNumber; //전화번호 - 연락처
+    private String userEmail; //아이디 이메일
+    private Long universityId; //학교 아이디
+    private Long organizationId; // 학교 단과대학 학과 이름
+    private Boolean academicStatus; //학적 상태
+    private UserRole role;
+    private int student_grade; //학년은 재학생 인증으로 INformation테이블이 만들어졌을 시
+
+}

--- a/src/main/java/org/example/wecambackend/dto/responseDTO/MyPageResponse.java
+++ b/src/main/java/org/example/wecambackend/dto/responseDTO/MyPageResponse.java
@@ -1,11 +1,15 @@
 package org.example.wecambackend.dto.responseDTO;
 
 
-import lombok.AllArgsConstructor;
-import lombok.Getter;
+import lombok.*;
+import org.example.wecambackend.model.enums.AcademicStatus;
 import org.example.wecambackend.model.enums.UserRole;
 
-@Getter
+import java.util.List;
+
+@Getter @Setter
+@Builder
+@NoArgsConstructor
 @AllArgsConstructor
 public class MyPageResponse {
     private String username; //이름
@@ -13,12 +17,15 @@ public class MyPageResponse {
     private String userEmail; //아이디 이메일
     private Long universityId; //학교 아이디
     private Long organizationId; // 학교 단과대학 학과 이름
-    private Boolean academicStatus; //학적 상태
+    private AcademicStatus academicStatus; //학적 상태
     private UserRole role;
     private int student_grade;
     private Boolean isAuthentication; //소속인증을 완료했는지 여부
     private Boolean isCouncilFee; // 학생회비 인증 완료했는지 여부
-    private Boolean nickName; //닉네임
-    private Boolean studentId; //학번
+    private String nickName; //닉네임
+    private String studentId; //학번
+
+    private List<String> organizationHierarchyList; // 전체 조직 이름 뜨게 하기
+
 
 }

--- a/src/main/java/org/example/wecambackend/dto/responseDTO/MyPageResponse.java
+++ b/src/main/java/org/example/wecambackend/dto/responseDTO/MyPageResponse.java
@@ -15,6 +15,6 @@ public class MyPageResponse {
     private Long organizationId; // 학교 단과대학 학과 이름
     private Boolean academicStatus; //학적 상태
     private UserRole role;
-    private int student_grade; //학년은 재학생 인증으로 INformation테이블이 만들어졌을 시
+    private int student_grade;
 
 }

--- a/src/main/java/org/example/wecambackend/dto/responseDTO/OcrResultResponse.java
+++ b/src/main/java/org/example/wecambackend/dto/responseDTO/OcrResultResponse.java
@@ -4,6 +4,7 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.hibernate.type.descriptor.jdbc.TinyIntJdbcType;
 
 @Getter
 @Builder
@@ -14,4 +15,5 @@ public class OcrResultResponse {
     private String schoolName;
     private String orgName;
     private String enrollYear;
+    private int schoolGrade;
 }

--- a/src/main/java/org/example/wecambackend/model/Organization.java
+++ b/src/main/java/org/example/wecambackend/model/Organization.java
@@ -4,10 +4,13 @@ import jakarta.persistence.*;
 import lombok.*;
 import org.example.wecambackend.model.common.BaseTimeEntity;
 import org.example.wecambackend.model.enums.OrganizationType;
-
+import org.hibernate.annotations.BatchSize;
 import java.util.ArrayList;
 import java.util.List;
 
+//N+1 쿼리 없애야돼서 lazy 로 묶어놔서 parent 찾을 때 막힘.
+//TODO: 추후 유지보수를 위해 변경해야될 수도 있음.
+@BatchSize(size = 5)
 @Entity
 @Table(name = "organization")
 @Getter

--- a/src/main/java/org/example/wecambackend/model/User/User.java
+++ b/src/main/java/org/example/wecambackend/model/User/User.java
@@ -61,7 +61,7 @@ public class User {
 
     /** 소속된 조직 (학과, 단과대 등) - 다대일 매핑 */
     //기본적으로 nullable = true --> 소속 인증 후 연결
-    @ManyToOne
+    @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "organization")
     private Organization organization;
 
@@ -76,6 +76,11 @@ public class User {
     /** 시스템 슈퍼유저 여부 (True인 경우 플랫폼 전체 관리 권한) */
     @Column(name = "is_superuser", nullable = false)
     private Boolean isSuperuser;
+
+
+    //추가됨. ocr 인증 마치고 소속 인증 승인 받으면 들어가는 데이터
+    @Column(name="enroll_year",length = 4)
+    private String enrollYear;
 
     /** 최초 생성 시 자동 설정되는 값들 */
     @PrePersist

--- a/src/main/java/org/example/wecambackend/model/User/User.java
+++ b/src/main/java/org/example/wecambackend/model/User/User.java
@@ -103,5 +103,4 @@ public class User {
         this.organization = organization;
         this.organizationId = organization != null ? organization.getOrganizationId() : null;
     }
-
 }

--- a/src/main/java/org/example/wecambackend/model/User/User.java
+++ b/src/main/java/org/example/wecambackend/model/User/User.java
@@ -65,7 +65,7 @@ public class User {
     @JoinColumn(name = "organization")
     private Organization organization;
 
-    @Column(name = "organization_id", insertable = false, updatable = false)
+    @Column(name = "organization_id")
     private Long organizationId;
 
     /** 사용자 역할 (UserRole 참고) */
@@ -106,6 +106,9 @@ public class User {
 
     public void setOrganization(Organization organization) {
         this.organization = organization;
-        this.organizationId = organization != null ? organization.getOrganizationId() : null;
+        if (organization == null) {
+            throw new IllegalArgumentException("organization은 null일 수 없습니다.");
+        }
+        this.organizationId =  organization.getOrganizationId();
     }
 }

--- a/src/main/java/org/example/wecambackend/model/User/UserInformation.java
+++ b/src/main/java/org/example/wecambackend/model/User/UserInformation.java
@@ -39,7 +39,7 @@ public class UserInformation extends BaseTimeEntity {
     private University university;
 
     @Column(name = "student_grade")
-    private Byte studentGrade;
+    private int studentGrade; //학년
 
     @Enumerated(EnumType.STRING)
     @Column(name = "academic_status")
@@ -56,6 +56,5 @@ public class UserInformation extends BaseTimeEntity {
 
     @Column(name = "is_council_fee", nullable = false)
     private Boolean isCouncilFee;
-
 
 }

--- a/src/main/java/org/example/wecambackend/model/User/UserSignupInformation.java
+++ b/src/main/java/org/example/wecambackend/model/User/UserSignupInformation.java
@@ -53,5 +53,4 @@ public class UserSignupInformation extends BaseTimeEntity {
     @Builder.Default
     private Boolean isMakeWorkspace = false;
 
-
 }

--- a/src/main/java/org/example/wecambackend/model/affiliation/AffiliationCertification.java
+++ b/src/main/java/org/example/wecambackend/model/affiliation/AffiliationCertification.java
@@ -32,6 +32,9 @@ public class AffiliationCertification {
     @Column(name = "authentication_type", insertable = false, updatable = false)
     private AuthenticationType authenticationType;
 
+    @Column(name="school_grade",nullable = false)
+    private int school_grade;
+
     @Enumerated(EnumType.STRING)
     @Column(name = "ocr_result", nullable = false)
     private OcrResult ocrResult;

--- a/src/main/java/org/example/wecambackend/model/affiliation/AffiliationCertification.java
+++ b/src/main/java/org/example/wecambackend/model/affiliation/AffiliationCertification.java
@@ -8,6 +8,7 @@ import org.example.wecambackend.model.User.User;
 import org.example.wecambackend.model.enums.AuthenticationStatus;
 import org.example.wecambackend.model.enums.AuthenticationType;
 import org.example.wecambackend.model.enums.OcrResult;
+import org.hibernate.type.descriptor.jdbc.TinyIntJdbcType;
 
 import java.time.LocalDateTime;
 
@@ -32,8 +33,8 @@ public class AffiliationCertification {
     @Column(name = "authentication_type", insertable = false, updatable = false)
     private AuthenticationType authenticationType;
 
-    @Column(name="school_grade",nullable = false)
-    private int school_grade;
+    @Column(name="ocr_school_grade",nullable = false)
+    private int ocrschoolGrade;
 
     @Enumerated(EnumType.STRING)
     @Column(name = "ocr_result", nullable = false)
@@ -67,11 +68,9 @@ public class AffiliationCertification {
     @Column(name = "reviewed_at")
     private LocalDateTime reviewedAt;
 
-
     @ManyToOne
     @JoinColumn(name = "pk_reviewer_userid")
     private User reviewUser;
-
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "school_pk_id")

--- a/src/main/java/org/example/wecambackend/repos/OrganizationRepository.java
+++ b/src/main/java/org/example/wecambackend/repos/OrganizationRepository.java
@@ -4,8 +4,11 @@ import org.example.wecambackend.model.Organization;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.List;
+import java.util.Optional;
 
 public interface OrganizationRepository extends JpaRepository<Organization, Long> {
     List<Organization> findByUniversity_SchoolIdAndLevel(Long schoolId, int level);
     List<Organization> findByParent_OrganizationId(Long parentId);
+
+    Optional<Organization> findByOrganizationId(Long organizationId);
 }

--- a/src/main/java/org/example/wecambackend/repos/SchoolRepository.java
+++ b/src/main/java/org/example/wecambackend/repos/SchoolRepository.java
@@ -4,5 +4,8 @@ package org.example.wecambackend.repos;
 import org.example.wecambackend.model.University;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.Optional;
+
 public interface SchoolRepository extends JpaRepository<University, Long> {
+    Optional<University> findBySchoolId(Long schoolId);
 }

--- a/src/main/java/org/example/wecambackend/repos/UserInformationRepository.java
+++ b/src/main/java/org/example/wecambackend/repos/UserInformationRepository.java
@@ -9,4 +9,5 @@ import java.util.Optional;
 public interface UserInformationRepository extends JpaRepository<UserInformation,Long> {
 
     Optional<UserInformation> findByUser(User user);
+    Optional<UserInformation> findByUser_UserPkId(Long userid);
 }

--- a/src/main/java/org/example/wecambackend/repos/UserInformationRepository.java
+++ b/src/main/java/org/example/wecambackend/repos/UserInformationRepository.java
@@ -1,8 +1,12 @@
 package org.example.wecambackend.repos;
 
+import org.example.wecambackend.model.User.User;
 import org.example.wecambackend.model.User.UserInformation;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.Optional;
+
 public interface UserInformationRepository extends JpaRepository<UserInformation,Long> {
 
+    Optional<UserInformation> findByUser(User user);
 }

--- a/src/main/java/org/example/wecambackend/repos/UserPrivateRepository.java
+++ b/src/main/java/org/example/wecambackend/repos/UserPrivateRepository.java
@@ -3,8 +3,15 @@ package org.example.wecambackend.repos;
 import org.example.wecambackend.model.User.User;
 import org.example.wecambackend.model.User.UserPrivate;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
+
+import java.util.Optional;
 
 @Repository
 public interface UserPrivateRepository  extends JpaRepository<UserPrivate, User> {
+
+    @Query("SELECT u.phoneNumber FROM UserPrivate u WHERE u.user.userPkId = :userId")
+    Optional<String> findEncryptedPhoneNumberByUserId(@Param("userId") Long userId);
 }

--- a/src/main/java/org/example/wecambackend/repos/UserRepository.java
+++ b/src/main/java/org/example/wecambackend/repos/UserRepository.java
@@ -14,7 +14,9 @@ public interface UserRepository extends JpaRepository<User, Long> {
 
     @Query("SELECT u FROM User u JOIN FETCH u.userPrivate WHERE u.email = :email")
     Optional<User> findByEmailWithPrivate(@Param("email") String email);
-
-
     boolean existsByEmail(String email);
+
+    @Query("SELECT u FROM User u LEFT JOIN FETCH u.organization WHERE u.userPkId = :id")
+    Optional<User> findByIdWithOrganization(@Param("id") Long id);
+
 }

--- a/src/main/java/org/example/wecambackend/service/admin/AffiliationCertificationAdminService.java
+++ b/src/main/java/org/example/wecambackend/service/admin/AffiliationCertificationAdminService.java
@@ -88,9 +88,10 @@ public class AffiliationCertificationAdminService {
         AuthenticationType type = cert.getAuthenticationType();
         User reviewUser = userRepository.findById(currentUser.getId())
                 .orElseThrow(() -> new RuntimeException("리뷰어 유저 없음"));
+        String enrollYear = cert.getOcrEnrollYear();
         markApproved(cert,reviewUser);
         userInformationService.createUserInformation(uploadUser, cert, type);
-        userService.updateUserRoleAndStatus(uploadUser, cert.getOrganization(),cert.getUniversity(), type);
+        userService.updateUserRoleAndStatus(uploadUser, cert.getOrganization(),cert.getUniversity(), type, enrollYear);
         log.info("[소속 인증 승인] {}가 {}의 인증 요청을 승인함",
                 reviewUser.getEmail(),
                 uploadUser.getEmail());

--- a/src/main/java/org/example/wecambackend/service/admin/AffiliationCertificationAdminService.java
+++ b/src/main/java/org/example/wecambackend/service/admin/AffiliationCertificationAdminService.java
@@ -89,7 +89,7 @@ public class AffiliationCertificationAdminService {
         User reviewUser = userRepository.findById(currentUser.getId())
                 .orElseThrow(() -> new RuntimeException("리뷰어 유저 없음"));
         markApproved(cert,reviewUser);
-        userInformationService.createUserInformation(uploadUser, cert);
+        userInformationService.createUserInformation(uploadUser, cert, type);
         userService.updateUserRoleAndStatus(uploadUser, cert.getOrganization(),cert.getUniversity(), type);
         log.info("[소속 인증 승인] {}가 {}의 인증 요청을 승인함",
                 reviewUser.getEmail(),

--- a/src/main/java/org/example/wecambackend/service/admin/AffiliationCertificationAdminService.java
+++ b/src/main/java/org/example/wecambackend/service/admin/AffiliationCertificationAdminService.java
@@ -7,11 +7,15 @@ import org.example.wecambackend.dto.projection.AffiliationFileProjection;
 import org.example.wecambackend.dto.responseDTO.AffiliationVerificationResponse;
 import org.example.wecambackend.exception.UnauthorizedException;
 import org.example.wecambackend.model.Council;
+import org.example.wecambackend.model.Organization;
+import org.example.wecambackend.model.University;
 import org.example.wecambackend.model.User.User;
 import org.example.wecambackend.model.affiliation.AffiliationCertification;
 import org.example.wecambackend.model.affiliation.AffiliationCertificationId;
 import org.example.wecambackend.model.enums.AuthenticationType;
 import org.example.wecambackend.repos.CouncilRepository;
+import org.example.wecambackend.repos.OrganizationRepository;
+import org.example.wecambackend.repos.SchoolRepository;
 import org.example.wecambackend.repos.UserRepository;
 import org.example.wecambackend.repos.affiliation.AffiliationCertificationRepository;
 import org.example.wecambackend.repos.affiliation.AffiliationFileRepository;
@@ -44,7 +48,6 @@ public class AffiliationCertificationAdminService {
             // 복합키 구성 정보
             Long userId = ac.getId().getUserId();
             AuthenticationType authenticationType = ac.getId().getAuthenticationType();
-            AffiliationCertificationId id = ac.getId();
 
             Optional<AffiliationFileProjection> optionalFile = affiliationFileRepository.findFilePathAndNameByUserIdAndAuthOrdinal(userId, authenticationType.ordinal());
             System.out.println("조회된 파일: " + optionalFile);
@@ -89,9 +92,16 @@ public class AffiliationCertificationAdminService {
         User reviewUser = userRepository.findById(currentUser.getId())
                 .orElseThrow(() -> new RuntimeException("리뷰어 유저 없음"));
         String enrollYear = cert.getOcrEnrollYear();
+
+        Organization organization = organizationRepository.findByOrganizationId(cert.getOrganization().getOrganizationId())
+                        .orElseThrow(()-> new IllegalArgumentException("해당 조직을 찾을 수 없습니다."));
+        University university = schoolRepository.findBySchoolId(cert.getUniversity().getSchoolId())
+                .orElseThrow(()-> new IllegalArgumentException("해당 학교를 찾을 수 없습니다."));
+
+        System.out.println(organization.getOrganizationName());
         markApproved(cert,reviewUser);
         userInformationService.createUserInformation(uploadUser, cert, type);
-        userService.updateUserRoleAndStatus(uploadUser, cert.getOrganization(),cert.getUniversity(), type, enrollYear);
+        userService.updateUserRoleAndStatus(uploadUser, organization,university, type, enrollYear);
         log.info("[소속 인증 승인] {}가 {}의 인증 요청을 승인함",
                 reviewUser.getEmail(),
                 uploadUser.getEmail());
@@ -106,4 +116,6 @@ public class AffiliationCertificationAdminService {
         affiliationCertificationRepository.save(cert); // dirty checking 보장 안되면 save
     }
 
+    private final OrganizationRepository organizationRepository;
+    private final SchoolRepository schoolRepository;
 }

--- a/src/main/java/org/example/wecambackend/service/admin/UserInformationService.java
+++ b/src/main/java/org/example/wecambackend/service/admin/UserInformationService.java
@@ -4,6 +4,7 @@ import lombok.RequiredArgsConstructor;
 import org.example.wecambackend.model.User.User;
 import org.example.wecambackend.model.User.UserInformation;
 import org.example.wecambackend.model.affiliation.AffiliationCertification;
+import org.example.wecambackend.model.enums.AuthenticationType;
 import org.example.wecambackend.repos.UserInformationRepository;
 import org.springframework.stereotype.Service;
 
@@ -15,16 +16,21 @@ public class UserInformationService {
 
 
     private final UserInformationRepository userInformationRepository;
-    public void createUserInformation( User user, AffiliationCertification cert) {
-        UserInformation info = UserInformation.builder()
-                .user(user)
-                .name(cert.getUsername())
-                .university(cert.getUniversity())
-                .isAuthentication(Boolean.TRUE)
-                .studentId(cert.getOcrEnrollYear())
-                .isCouncilFee(Boolean.FALSE)
-                .build();
 
-        userInformationRepository.save(info);
+    public void createUserInformation(User user, AffiliationCertification cert, AuthenticationType type) {
+        UserInformation info = userInformationRepository.findByUser(user)
+                .orElse(null); // 있으면 수정하는 방향 , 없으면 생성
+        if (info == null) {
+            info = UserInformation.builder()
+                    .user(user)
+                    .name(cert.getUsername())
+                    .university(cert.getUniversity())
+                    .isAuthentication(Boolean.TRUE)
+                    .studentId(cert.getOcrEnrollYear())
+                    .isCouncilFee(Boolean.FALSE)
+                    .build();
+            userInformationRepository.save(info);
+        }
+
     }
 }

--- a/src/main/java/org/example/wecambackend/service/admin/UserInformationService.java
+++ b/src/main/java/org/example/wecambackend/service/admin/UserInformationService.java
@@ -15,6 +15,7 @@ import java.time.LocalDateTime;
 public class UserInformationService {
 
 
+    //TODO : 조직 수정 까지는 구현 안함. 단순 신입생 인증 했을 때와 재학생 인증 시 다를 수 있는 정보가 있을 때 만들 예정
     private final UserInformationRepository userInformationRepository;
 
     public void createUserInformation(User user, AffiliationCertification cert, AuthenticationType type) {
@@ -26,8 +27,8 @@ public class UserInformationService {
                     .name(cert.getUsername())
                     .university(cert.getUniversity())
                     .isAuthentication(Boolean.TRUE)
-                    .studentId(cert.getOcrEnrollYear())
                     .isCouncilFee(Boolean.FALSE)
+                    .studentGrade(cert.getOcrschoolGrade())
                     .build();
             userInformationRepository.save(info);
         }

--- a/src/main/java/org/example/wecambackend/service/client/Affiliation/AffiliationService.java
+++ b/src/main/java/org/example/wecambackend/service/client/Affiliation/AffiliationService.java
@@ -3,6 +3,7 @@ package org.example.wecambackend.service.client.Affiliation;
 import io.swagger.v3.oas.annotations.Operation;
 import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
+import org.example.wecambackend.dto.projection.OcrEvaluationResult;
 import org.example.wecambackend.dto.responseDTO.OcrResultResponse;
 import org.example.wecambackend.exception.DuplicateSubmissionException;
 import org.example.wecambackend.model.Organization;
@@ -19,6 +20,8 @@ import org.example.wecambackend.repos.affiliation.AffiliationCertificationReposi
 import org.springframework.stereotype.Service;
 import org.springframework.web.multipart.MultipartFile;
 import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Map;
 import java.util.UUID;
 import java.util.stream.Stream;
@@ -70,16 +73,29 @@ public class AffiliationService {
 
         // 5. OCR 수행 → 결과 DTO로 매핑
         Map<String, String> result = ocrService.requestOcr(file);
+        String raw = result.get("schoolGrade");
+        int schoolGrade;
+        //OCR 결과값이 제대로 반출 안됐을 것을 고려해서, 자동으로 신입생일 경우 1 고정 , 아닐 경우 ocr결과를 기반으로 하되, 에러처리
+        //TODO : OCR 만들 때, 제대로 1,2,3,4 로 나오게끔 하고 만약 값처리가 분명하지 않다면 0 으로 처리하게끔 해줘야될듯.
+        if (status == AuthenticationType.NEW_STUDENT) {
+            schoolGrade = 1;
+        } else {
+            try {
+                schoolGrade = Integer.parseInt(raw);
+            } catch (NumberFormatException e) {
+                throw new IllegalArgumentException("OCR 결과 schoolGrade가 숫자가 아닙니다: " + raw);
+            }
+        }
         OcrResultResponse ocrResultDto = OcrResultResponse.builder()
                 .userName(result.get("userName"))
                 .schoolName(result.get("schoolName"))
                 .orgName(result.get("orgName"))
                 .enrollYear(result.get("enrollYear"))
+                .schoolGrade(schoolGrade)
                 .build();
 
         // 6. OCR 결과 판단
-        OcrResult ocrResult = determineFreshmanOcrResult(signupInfo, ocrResultDto, school, organization);
-
+        OcrEvaluationResult ocrResult = determineFreshmanOcrResult(signupInfo, ocrResultDto, school, organization);
 
         AffiliationCertification cert;
         // 7. 인증 정보 저장 - 신입생 인증 정보 저장
@@ -97,7 +113,9 @@ public class AffiliationService {
                 .ocrEnrollYear(ocrResultDto.getEnrollYear())
                 .ocrSchoolName(ocrResultDto.getSchoolName())
                 .ocrOrganizationName(ocrResultDto.getOrgName())
-                .ocrResult(ocrResult)
+                 .ocrschoolGrade(ocrResultDto.getSchoolGrade())
+                .ocrResult(ocrResult.getResult())
+                 .reason(ocrResult.getReason())
                 .status(AuthenticationStatus.PENDING)
                 .requestedAt(LocalDateTime.now())
                 .organization(organization)
@@ -114,40 +132,57 @@ public class AffiliationService {
     }
 
     //신입생 OCR 결과값 평가
-    public OcrResult determineFreshmanOcrResult(UserSignupInformation signupInfo,
-                                        OcrResultResponse ocrResult,
-                                        University school,
-                                        Organization org) {
+    public OcrEvaluationResult determineFreshmanOcrResult(
+            UserSignupInformation signupInfo,
+            OcrResultResponse ocrResult,
+            University school,
+            Organization org) {
 
         int matchCount = 0;
+        List<String> matchedFields = new ArrayList<>();
 
         // 1. 이름 비교
-        if (equalsIgnoreCaseSafe(signupInfo.getName(), ocrResult.getUserName())) matchCount++;
+        if (equalsIgnoreCaseSafe(signupInfo.getName(), ocrResult.getUserName())) {
+            matchCount++;
+            matchedFields.add("이름");
+        }
 
         // 2. 입학년도 비교
-        if (signupInfo.getEnrollYear().equals(ocrResult.getEnrollYear())) matchCount++;
+        if (signupInfo.getEnrollYear().equals(ocrResult.getEnrollYear())) {
+            matchCount++;
+            matchedFields.add("입학년도");
+        }
 
         // 3. 학교 이름 비교 (부분 일치 허용)
-        if (school.getSchoolName().contains(ocrResult.getSchoolName())) matchCount++;
+        if (school.getSchoolName().contains(ocrResult.getSchoolName())) {
+            matchCount++;
+            matchedFields.add("학교명");
+        }
 
         // 4. 소속 이름 비교 (부분 일치 허용)
-        if (org.getOrganizationName().contains(ocrResult.getOrgName())) matchCount++;
+        if (org.getOrganizationName().contains(ocrResult.getOrgName())) {
+            matchCount++;
+            matchedFields.add("소속명");
+        }
 
-        // OCR 실패 판단 (결과값 자체가 비어 있는 경우)
+        // OCR 실패 판단 (빈 값 포함)
         if (Stream.of(
                 ocrResult.getUserName(),
                 ocrResult.getSchoolName(),
                 ocrResult.getOrgName(),
                 ocrResult.getEnrollYear()
-        ).anyMatch(s -> s == null || s.isBlank())
-        ) {
-            return OcrResult.FAILURE;
+        ).anyMatch(s -> s == null || s.isBlank())) {
+            return new OcrEvaluationResult(OcrResult.FAILURE, "OCR 결과에 누락된 정보가 존재합니다.");
         }
 
         // 판단 기준
-        if (matchCount == 4) return OcrResult.SUCCESS;
-        else if (matchCount >= 1) return OcrResult.UNCLEAR;
-        else return OcrResult.FAILURE;
+        if (matchCount == 4) {
+            return new OcrEvaluationResult(OcrResult.SUCCESS, "모든 정보가 일치합니다: " + String.join(", ", matchedFields));
+        } else if (matchCount >= 1) {
+            return new OcrEvaluationResult(OcrResult.UNCLEAR, "일치한 정보: " + String.join(", ", matchedFields));
+        } else {
+            return new OcrEvaluationResult(OcrResult.FAILURE, "일치하는 정보가 없습니다.");
+        }
     }
 
     private boolean equalsIgnoreCaseSafe(String a, String b) {

--- a/src/main/java/org/example/wecambackend/service/client/Affiliation/OcrService.java
+++ b/src/main/java/org/example/wecambackend/service/client/Affiliation/OcrService.java
@@ -39,7 +39,7 @@ public class OcrService {
             headers.setContentType(MediaType.MULTIPART_FORM_DATA);
 
             HttpEntity<MultiValueMap<String, Object>> requestEntity = new HttpEntity<>(body, headers);
-
+            //userName , schoolName , orgName , enrollYear , schoolGrade 넘어오게 해놨음.
             ResponseEntity<Map> response = restTemplate.exchange(
                     ocrApiUrl, HttpMethod.POST, requestEntity, Map.class
             );

--- a/src/main/java/org/example/wecambackend/service/client/MyPageService.java
+++ b/src/main/java/org/example/wecambackend/service/client/MyPageService.java
@@ -1,0 +1,17 @@
+//package org.example.wecambackend.service.client;
+//
+//import lombok.RequiredArgsConstructor;
+//import lombok.extern.slf4j.Slf4j;
+//import org.example.wecambackend.config.security.UserDetailsImpl;
+//import org.example.wecambackend.dto.responseDTO.MyPageResponse;
+//import org.springframework.stereotype.Service;
+//
+//@Slf4j
+//@RequiredArgsConstructor
+//@Service
+//public class MyPageService {
+//    public MyPageResponse getMyPageInfo(UserDetailsImpl currentUser) {
+//        MyPageResponse MyPageResponse;
+//        return MyPageResponse;
+//    }
+//}

--- a/src/main/java/org/example/wecambackend/service/client/MyPageService.java
+++ b/src/main/java/org/example/wecambackend/service/client/MyPageService.java
@@ -1,17 +1,79 @@
-//package org.example.wecambackend.service.client;
-//
-//import lombok.RequiredArgsConstructor;
-//import lombok.extern.slf4j.Slf4j;
-//import org.example.wecambackend.config.security.UserDetailsImpl;
-//import org.example.wecambackend.dto.responseDTO.MyPageResponse;
-//import org.springframework.stereotype.Service;
-//
-//@Slf4j
-//@RequiredArgsConstructor
-//@Service
-//public class MyPageService {
-//    public MyPageResponse getMyPageInfo(UserDetailsImpl currentUser) {
-//        MyPageResponse MyPageResponse;
-//        return MyPageResponse;
-//    }
-//}
+package org.example.wecambackend.service.client;
+
+import org.springframework.transaction.annotation.Transactional;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.example.wecambackend.config.security.UserDetailsImpl;
+import org.example.wecambackend.dto.responseDTO.MyPageResponse;
+import org.example.wecambackend.model.Organization;
+import org.example.wecambackend.model.User.User;
+import org.example.wecambackend.model.User.UserInformation;
+import org.example.wecambackend.repos.UserInformationRepository;
+import org.example.wecambackend.repos.UserPrivateRepository;
+import org.example.wecambackend.repos.UserRepository;
+import org.springframework.stereotype.Service;
+import org.example.wecambackend.util.PhoneEncryptor;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+
+@Slf4j
+@RequiredArgsConstructor
+@Service
+public class MyPageService {
+
+    private final UserRepository userRepository;
+    private final UserInformationRepository userInformationRepository;
+    private final PhoneEncryptor phoneEncryptor;
+    private final UserPrivateRepository userPrivateRepository;
+
+    @Transactional(readOnly = true)
+    public MyPageResponse getMyPageInfo(UserDetailsImpl currentUser) {
+
+        // 1. 유저 + organization 즉시 로딩
+        User user = userRepository.findByIdWithOrganization(currentUser.getId())
+                .orElseThrow(() -> new RuntimeException("유저 없음"));
+
+        // 2. 유저 정보
+        UserInformation info = userInformationRepository.findByUser_UserPkId(currentUser.getId())
+                .orElseThrow(() -> new RuntimeException("유저 정보 없음."));
+
+        // 3. 전화번호 복호화
+        String phoneNumber = phoneEncryptor.decrypt(
+                userPrivateRepository.findEncryptedPhoneNumberByUserId(currentUser.getId())
+                        .orElseThrow(() -> new IllegalStateException("전화번호 정보 없음."))
+        );
+
+        // 4. 조직 계층 이름 리스트
+        List<String> hierarchyList = getOrganizationNameHierarchy(user.getOrganization());
+
+        return MyPageResponse.builder()
+                .organizationId(user.getOrganizationId())
+                .role(user.getRole())
+                .academicStatus(info.getAcademicStatus())
+                .isAuthentication(user.isAuthentication())
+                .isCouncilFee(info.getIsCouncilFee())
+                .nickName(info.getNickname())
+                .student_grade(info.getStudentGrade())
+                .userEmail(user.getEmail())
+                .phoneNumber(phoneNumber)
+                .studentId(info.getStudentId())
+                .universityId(info.getUniversity().getSchoolId())
+                .organizationHierarchyList(hierarchyList)
+                .username(info.getName())
+                .build();
+    }
+
+    // 조직 계층 이름 추출
+    private List<String> getOrganizationNameHierarchy(Organization org) {
+        List<String> names = new ArrayList<>();
+        while (org != null) {
+            names.add(org.getOrganizationName());
+            org = org.getParent();
+        }
+        Collections.reverse(names);
+        return names;
+    }
+}

--- a/src/main/java/org/example/wecambackend/service/client/UserService.java
+++ b/src/main/java/org/example/wecambackend/service/client/UserService.java
@@ -18,8 +18,9 @@ import java.time.LocalDateTime;
 @RequiredArgsConstructor
 public class UserService {
 
+    // TODO:  user.setOrganization(organization); 값 확인 해봐야 함. ORganizationId가 안들어가짐.
     private final UserRepository userRepository;
-    public void updateUserRoleAndStatus(User user, Organization organization, University university, AuthenticationType authenticationType) {
+    public void updateUserRoleAndStatus(User user, Organization organization, University university, AuthenticationType authenticationType,String enrollYear) {
         UserRole beforeRole = user.getRole();
         if (authenticationType == AuthenticationType.NEW_STUDENT) {
             user.setRole(UserRole.GUEST_STUDENT); // enum 기반
@@ -27,6 +28,7 @@ public class UserService {
         else {
             user.setRole(UserRole.STUDENT);
         }
+        user.setEnrollYear(enrollYear);
         if (!beforeRole.equals(user.getRole())) {
             user.setExpiresAt(null); // TODO : 우선 ROLE 이 바뀌면 ExpiresAt은 비활성화 시켰음.
         }

--- a/src/main/java/org/example/wecambackend/service/client/UserService.java
+++ b/src/main/java/org/example/wecambackend/service/client/UserService.java
@@ -32,6 +32,7 @@ public class UserService {
         if (!beforeRole.equals(user.getRole())) {
             user.setExpiresAt(null); // TODO : 우선 ROLE 이 바뀌면 ExpiresAt은 비활성화 시켰음.
         }
+        user.setAuthentication(true);
         user.setUniversity(university);
         user.setOrganization(organization);
 

--- a/src/main/resources/db/schema.sql
+++ b/src/main/resources/db/schema.sql
@@ -1,23 +1,7 @@
-UPDATE affiliation_certification
-SET authentication_type = 'NEW_STUDENT'
-WHERE authentication_type = '0';
-
-ALTER TABLE affiliation_file
-    MODIFY authentication_type ENUM('NEW_STUDENT', 'CURRENT_STUDENT') NOT NULL;
-
-
-UPDATE affiliation_file
-SET authentication_type = 'NEW_STUDENT'
-WHERE authentication_type = '0';
-
-UPDATE affiliation_file
-SET authentication_type = 'TRANSFER'
-WHERE authentication_type = '1';
-
-
-SELECT * FROM affiliation_file
-WHERE pk_upload_userid = 1 AND authentication_type = 'NEW_STUDENT';
-
-
 ALTER TABLE affiliation_certification ADD COLUMN user_name VARCHAR(255);
 ALTER TABLE user MODIFY expires_at DATETIME NULL;
+
+ALTER TABLE user ADD COLUMN enroll_year VARCHAR(4);
+
+ALTER TABLE affiliation_certification ADD COLUMN ocr_school_grade INT;
+ALTER TABLE user_information MODIFY COLUMN student_grade INT;

--- a/src/main/resources/db/user.sql
+++ b/src/main/resources/db/user.sql
@@ -2,11 +2,11 @@
 INSERT INTO user (
     is_authentication, is_email_verified, is_superuser,
     created_at, expires_at, organization_id, updated_at,
-    email, role,organization,school_id
+    email, role,organization,school_id,enroll_year
 ) VALUES (
              1, 1, 0,
              NOW(), DATE_ADD(NOW(), INTERVAL 1 YEAR), 303, NOW(),
-             'president@example.com', 'COUNCIL',303,2
+             'president@example.com', 'COUNCIL',303,2,'2021'
          );
 
 INSERT INTO user_private (

--- a/src/main/resources/static/mypage_example.html
+++ b/src/main/resources/static/mypage_example.html
@@ -1,0 +1,103 @@
+<!DOCTYPE html>
+<html lang="ko">
+<head>
+    <meta charset="UTF-8">
+    <title>마이페이지</title>
+    <style>
+        body {
+            font-family: 'Noto Sans KR', sans-serif;
+            background-color: #f4f4f4;
+            margin: 20px;
+        }
+        .container {
+            background-color: white;
+            padding: 30px;
+            border-radius: 10px;
+            max-width: 600px;
+            margin: auto;
+            box-shadow: 0 0 10px rgba(0,0,0,0.1);
+        }
+        h2 {
+            text-align: center;
+            margin-bottom: 30px;
+        }
+        .info-row {
+            display: flex;
+            justify-content: space-between;
+            margin-bottom: 10px;
+        }
+        .info-label {
+            font-weight: bold;
+        }
+        .info-value {
+            color: #333;
+        }
+    </style>
+</head>
+<body>
+<div class="container">
+    <h2>마이페이지</h2>
+    <div class="info-row"><span class="info-label">이름:</span> <span id="username" class="info-value"></span></div>
+    <div class="info-row"><span class="info-label">전화번호:</span> <span id="phoneNumber" class="info-value"></span></div>
+    <div class="info-row"><span class="info-label">이메일:</span> <span id="userEmail" class="info-value"></span></div>
+    <div class="info-row"><span class="info-label">학교 ID:</span> <span id="universityId" class="info-value"></span></div>
+    <div class="info-row"><span class="info-label">조직 ID:</span> <span id="organizationId" class="info-value"></span></div>
+    <div class="info-row"><span class="info-label">학적 상태:</span> <span id="academicStatus" class="info-value"></span></div>
+    <div class="info-row"><span class="info-label">역할:</span> <span id="role" class="info-value"></span></div>
+    <div class="info-row"><span class="info-label">학년:</span> <span id="studentGrade" class="info-value"></span></div>
+    <div class="info-row"><span class="info-label">소속 인증:</span> <span id="isAuthentication" class="info-value"></span></div>
+    <div class="info-row"><span class="info-label">학생회비 인증:</span> <span id="isCouncilFee" class="info-value"></span></div>
+    <div class="info-row"><span class="info-label">닉네임:</span> <span id="nickName" class="info-value"></span></div>
+    <div class="info-row"><span class="info-label">학번:</span> <span id="studentId" class="info-value"></span></div>
+    <!-- 중첩 제거 -->
+    <div class="info-row"><span class="info-label">조직 계층 (문자열):</span> <span id="organizationPath" class="info-value"></span></div>
+    <div class="info-row"><span class="info-label">조직 계층 (리스트):</span>
+        <ul id="organizationList" class="info-value" style="margin-left: 10px;"></ul>
+    </div>
+</div>
+
+<script>
+    // 실제 API 호출
+    fetch("/client/user/mypage", {
+        method: "GET",
+        credentials: "include", // 세션 or 쿠키 인증 필요 시
+        headers: {
+            "Content-Type": "application/json",
+            "Authorization": "Bearer " + localStorage.getItem("accessToken") // 필요한 경우
+        }
+    })
+        .then(response => {
+            if (!response.ok) {
+                throw new Error("마이페이지 정보를 불러오는 데 실패했습니다.");
+            }
+            return response.json();
+        })
+        .then(data => {
+            // 1. 일반 필드 출력
+            Object.entries(data).forEach(([key, value]) => {
+                const element = document.getElementById(key);
+                if (element && !Array.isArray(value)) {
+                    element.textContent = value;
+                }
+            });
+
+            // 2. 조직 계층 처리
+            const pathElement = document.getElementById("organizationPath");
+            const listElement = document.getElementById("organizationList");
+
+            if (data.organizationHierarchyList && Array.isArray(data.organizationHierarchyList)) {
+                pathElement.textContent = data.organizationHierarchyList.join(" > ");
+                data.organizationHierarchyList.forEach(name => {
+                    const li = document.createElement("li");
+                    li.textContent = name;
+                    listElement.appendChild(li);
+                });
+            }
+        })
+        .catch(error => {
+            alert(error.message);
+            console.error(error);
+        });
+</script>
+</body>
+</html>


### PR DESCRIPTION
#  PR: 마이페이지 조회 기능 구현 (`/client/user/mypage`)

### 주요 목적

* 로그인된 유저의 마이페이지 정보를 백엔드에서 조회해 프론트에 제공하는 API 구현
* 사용자 정보뿐 아니라, 암호화된 전화번호 복호화, 소속 조직의 계층 구조까지 포함한 상세 정보 제공

---

## 주요 변경 사항

### 1. `GET /client/user/mypage` API 추가

* `UserMyPageController`에서 로그인된 사용자 정보를 기반으로 마이페이지 정보 조회
* `@AuthenticationPrincipal`을 통해 JWT 인증된 유저 정보 수신
* 서비스로 위임하여 사용자 정보, 조직, 전화번호, 학교, 학적 상태 등을 한 번에 묶어서 반환

```java
@GetMapping
public ResponseEntity<MyPageResponse> getMyInfo(@AuthenticationPrincipal UserDetailsImpl userDetails) {
    return ResponseEntity.ok(myPageService.getMyPageInfo(userDetails));
}
```

---

### 2. `MyPageService` 로직 상세 구현

* 트랜잭션 범위에서 LazyLoading 문제 방지 → `@Transactional(readOnly = true)` 적용
* 유저 조회 시 `User`와 `Organization`을 `fetch join`으로 한 번에 로딩
* 암호화된 전화번호를 `PhoneEncryptor`로 복호화 처리
* 소속 조직의 계층 구조를 재귀적으로 추출하여 프론트에 전달

```java
@Transactional(readOnly = true)
public MyPageResponse getMyPageInfo(UserDetailsImpl currentUser) {
    User user = userRepository.findByIdWithOrganization(currentUser.getId())
            .orElseThrow(() -> new RuntimeException("유저 없음"));

    UserInformation info = userInformationRepository.findByUser_UserPkId(currentUser.getId())
            .orElseThrow(() -> new RuntimeException("유저 정보 없음."));

    String phoneNumber = phoneEncryptor.decrypt(
        userPrivateRepository.findEncryptedPhoneNumberByUserId(currentUser.getId())
                .orElseThrow(() -> new IllegalStateException("전화번호 정보 없음."))
    );

    List<String> hierarchyList = getOrganizationNameHierarchy(user.getOrganization());

    return MyPageResponse.builder()
            .username(info.getName())
            .phoneNumber(phoneNumber)
            .userEmail(user.getEmail())
            .universityId(info.getUniversity().getSchoolId())
            .organizationId(user.getOrganizationId())
            .organizationHierarchyList(hierarchyList)
            .academicStatus(info.getAcademicStatus())
            .role(user.getRole())
            .student_grade(info.getStudentGrade())
            .isAuthentication(user.isAuthentication())
            .isCouncilFee(info.getIsCouncilFee())
            .studentId(info.getStudentId())
            .build();
}
```

---

### 3. 조직 계층 재귀 처리 함수

* `Organization` 엔티티는 자기 참조 구조 (`parent`)를 가지므로, `부서 → 단과대학 → 학교` 순서로 올라가며 이름을 리스트에 담고, 최종적으로 역순으로 정렬

```java
private List<String> getOrganizationNameHierarchy(Organization org) {
    List<String> names = new ArrayList<>();
    while (org != null) {
        names.add(org.getOrganizationName());
        org = org.getParent(); // lazy loading 발생 주의
    }
    Collections.reverse(names);
    return names;
}
```

---

### 4. 쿼리 최적화

* `User` → `Organization` 관계는 LAZY로 되어 있으므로, `fetch join` 사용하여 한 번에 로딩되도록 최적화

```java
@Query("SELECT u FROM User u LEFT JOIN FETCH u.organization WHERE u.userPkId = :id")
Optional<User> findByIdWithOrganization(@Param("id") Long id);
```

---

### 5. 전화번호 필드 복호화 처리

* `UserPrivate`의 `phoneNumber`는 암호화된 상태로 저장되어 있으며,
* `UserPrivateRepository`에서 해당 필드만 조회하여 복호화 후 반환

```java
@Query("SELECT u.phoneNumber FROM UserPrivate u WHERE u.user.userPkId = :userId")
Optional<String> findEncryptedPhoneNumberByUserId(@Param("userId") Long userId);
```

---

### 6. Lazy 쿼리 최적화 대응

* `Organization`의 parent 계층 조회에서 N+1 문제 방지를 위해 `@BatchSize(size = 5)` 적용
* 최대 4단계 정도의 조직 계층에서는 성능 저하 없이 문제 해결 가능

```java
@BatchSize(size = 5)
@Entity
@Table(name = "organization")
public class Organization { ... }
```

---

##  기타 주석 및 고려사항

* 현재는 `getParent()`가 재귀 호출되므로, 트랜잭션 범위 안에서만 접근이 가능하며 `LazyInitializationException`을 방지하기 위해 반드시 서비스 메서드에 `@Transactional`이 필요함
* 추후 유지보수를 고려해 `Organization`을 flatten된 path 문자열로 저장하는 구조 도입도 가능함

---

##  테스트 확인 포인트

* [x] 마이페이지 호출 시 유저 기본 정보 정상 반환
* [x] 전화번호 복호화 정상 작동
* [x] 조직 계층 리스트 테스트 JSON 전달 확인
* [x] LazyLoading 문제 없음 (트랜잭션 + fetch join 처리)


---

##  향후 추가 부분

* 조직 계층 구조를 별도의 DTO로 분리하거나, `조직명 > 단과대 > 학교` 형식의 `flattenedPath` 필드로 제공
* 활동 이력 추가

---